### PR TITLE
add babel-preset-es2015

### DIFF
--- a/hooks/transform.js
+++ b/hooks/transform.js
@@ -142,7 +142,7 @@ class TransformPlugin extends BasePlugin {
   transformJs(filePath) {
     this.log(`Transforming JS with Babel ${filePath} -> ${filePath}`);
     return new Promise((resolve, reject) => {
-      babel.transformFile(filePath, (err, result) => {
+      babel.transformFile(filePath, this.getBabelOptions(), (err, result) => {
         if (err) {
           reject(err);
         } else {
@@ -170,6 +170,12 @@ class TransformPlugin extends BasePlugin {
     }))
       .then(tss => fs.outputFile(tssFilePath, tss))
       .then(() => fs.remove(filePath));
+  }
+
+  getBabelOptions() {
+    return {
+      presets: ['es2015'],
+    };
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   "license": "MIT",
   "dependencies": {
     "babel-core": "^6.24.1",
+    "babel-preset-es2015": "^6.24.1",
     "chokidar": "^1.7.0",
     "fs-extra": "^3.0.1",
     "klaw-sync": "^2.1.0",


### PR DESCRIPTION
https://github.com/vladm3/alloy.babel/issues/2

src/controllers/index.js
```
const a = 'test';

var doClick = (e) => {
  alert($.label.text + a);
}

$.index.open();
```

This is transcoded result.

app/controllers/index.js
```
'use strict';

var a = 'test';

var doClick = function doClick(e) {
  alert($.label.text + a);
};

$.index.open();
```

I think ES2015 (ex: arrow functions, const, let) are already used as standard, so we need es2015 preset.

Thank you.